### PR TITLE
master-merge-NCP-2509

### DIFF
--- a/ru_RU.json
+++ b/ru_RU.json
@@ -34,7 +34,7 @@
 	"banner.info.text.edgehost": "edge-имя хоста",
 	"banner.info.text.edgehost.plural": "edge-имен хостов",
 	"banner.info.text.property": "acceleration конфигурации",
-	"banner.info.text.property.plural": "acceleration конфигурации",
+	"banner.info.text.property.plural": "acceleration конфигураци(и, й)",
 	"brand.footer.copyright.cdnetwork": "Copyright © 2021 CDNetworks, Inc. Все права защищены.",
 	"brand.footer.copyright.quantil": "© 2021 QUANTIL. Все права защищены.",
 	"btn.text.cache.setting.wizard": "Мастер настроек",


### PR DESCRIPTION
NCP-2509: Errors in displaying information panel with count of properties, certificates, cnames on Dashboard in Russian language.
An issue: https://quantil.atlassian.net/browse/NCP-2509