### PR TITLE
master-merge-NCP-2510

### DIFF
--- a/ru_RU.json
+++ b/ru_RU.json
@@ -1010,7 +1010,7 @@
 	"placeholder.property.version.desc": "Что изменилось в этой вресии?",
 	"popover.tooltip.cache.time": "Установите время кеширования для кодов ответа 200, 301 и 302.",
 	"prod.deployment.not.allowed": "У вас нет разрешения на развертывание в продуктивной среде. Обратитесь в службу поддержки.",
-	"products.switch.to": "Переключиться на",
+	"products.switch.to": "Выбрать",
 	"products.title.cdn": "CDN",
 	"products.title.ecp": "ECP",
 	"products.title.hdt": "HDT",


### PR DESCRIPTION
NCP-2510: ‘Переключиться на‘ in product selector is truncated and displayed in two lines.

**Do not review this until merged:** https://github.com/mileweb/ngportal-language/pull/192/files

An issue: https://quantil.atlassian.net/browse/NCP-2510