### PR TITLE
[NCP-3228] Added report.export.group.csv.text

### DIFF
--- a/ar_SA.json
+++ b/ar_SA.json
@@ -1750,6 +1750,7 @@
 	"report.domainGroup.save.button": "+ حفظ أسماء المضيف المحددة كمجموعة",
 	"report.edgeHostnameReq.label.requests": "Requests",
 	"report.edgeHostnameReq.label.requests.per.sec": "Requests / Second",
+	"report.export.group.csv.text": "تصدير المجموعات إلى CSV",
 	"report.fast.req.label.requests": "Fast Route Requests",
 	"report.fast.req.label.requests.per.sec": "Requests / Second",
 	"report.fast.vol.label.traffic.down.vol": "Download Traffic",

--- a/en_US.json
+++ b/en_US.json
@@ -1750,6 +1750,7 @@
 	"report.domainGroup.save.button": "+ Save selected hostnames as a group",
 	"report.edgeHostnameReq.label.requests": "Requests",
 	"report.edgeHostnameReq.label.requests.per.sec": "Requests / Second",
+	"report.export.group.csv.text": "Export groups to CSV",
 	"report.fast.req.label.requests": "Fast Route Requests",
 	"report.fast.req.label.requests.per.sec": "Requests / Second",
 	"report.fast.vol.label.traffic.down.vol": "Download Traffic",

--- a/es_ES.json
+++ b/es_ES.json
@@ -1750,6 +1750,7 @@
 	"report.domainGroup.save.button": "+ Guardar nombres de host seleccionados como un grupo",
 	"report.edgeHostnameReq.label.requests": "Requests",
 	"report.edgeHostnameReq.label.requests.per.sec": "Requests / Second",
+	"report.export.group.csv.text": "Exportar grupos a CSV",
 	"report.fast.req.label.requests": "Fast Route Requests",
 	"report.fast.req.label.requests.per.sec": "Requests / Second",
 	"report.fast.vol.label.traffic.down.vol": "Download Traffic",

--- a/fr_FR.json
+++ b/fr_FR.json
@@ -1750,6 +1750,7 @@
 	"report.domainGroup.save.button": "+ Enregistrer les noms d'hôte sélectionnés en tant que groupe",
 	"report.edgeHostnameReq.label.requests": "Requests",
 	"report.edgeHostnameReq.label.requests.per.sec": "Requests / Second",
+	"report.export.group.csv.text": "Exporter des groupes vers CSV",
 	"report.fast.req.label.requests": "Fast Route Requests",
 	"report.fast.req.label.requests.per.sec": "Requests / Second",
 	"report.fast.vol.label.traffic.down.vol": "Download Traffic",

--- a/it_IT.json
+++ b/it_IT.json
@@ -1750,6 +1750,7 @@
 	"report.domainGroup.save.button": "+ Salva i nomi host selezionati come gruppo",
 	"report.edgeHostnameReq.label.requests": "Requests",
 	"report.edgeHostnameReq.label.requests.per.sec": "Requests / Second",
+	"report.export.group.csv.text": "Esporta i gruppi in CSV",
 	"report.fast.req.label.requests": "Fast Route Requests",
 	"report.fast.req.label.requests.per.sec": "Requests / Second",
 	"report.fast.vol.label.traffic.down.vol": "Download Traffic",

--- a/jk_KR.json
+++ b/jk_KR.json
@@ -1750,6 +1750,7 @@
 	"report.domainGroup.save.button": "+ 선택한 호스트 이름을 그룹으로 저장",
 	"report.edgeHostnameReq.label.requests": "Requests",
 	"report.edgeHostnameReq.label.requests.per.sec": "Requests / Second",
+	"report.export.group.csv.text": "그룹을 CSV로 내보내기",
 	"report.fast.req.label.requests": "Fast Route Requests",
 	"report.fast.req.label.requests.per.sec": "Requests / Second",
 	"report.fast.vol.label.traffic.down.vol": "Download Traffic",

--- a/jp_JP.json
+++ b/jp_JP.json
@@ -1750,6 +1750,7 @@
 	"report.domainGroup.save.button": "+選択したホスト名をグループとして保存します",
 	"report.edgeHostnameReq.label.requests": "リクエスト",
 	"report.edgeHostnameReq.label.requests.per.sec": "リクエスト / 秒",
+	"report.export.group.csv.text": "グループを CSV にエクスポートする",
 	"report.fast.req.label.requests": "高速ルートのリクエスト",
 	"report.fast.req.label.requests.per.sec": "リクエスト / 秒",
 	"report.fast.vol.label.traffic.down.vol": "ダウンロードトラフィック",

--- a/ru_RU.json
+++ b/ru_RU.json
@@ -1750,6 +1750,7 @@
 	"report.domainGroup.save.button": "+ Сохранить выбранные имена хостов как группу",
 	"report.edgeHostnameReq.label.requests": "Запросы",
 	"report.edgeHostnameReq.label.requests.per.sec": "Запросы / Сек",
+	"report.export.group.csv.text": "Экспортировать группы в CSV",
 	"report.fast.req.label.requests": "Fast Route Запросы",
 	"report.fast.req.label.requests.per.sec": "Запросы / Сек",
 	"report.fast.vol.label.traffic.down.vol": "Трафик скачивания",

--- a/zh-Hans.json
+++ b/zh-Hans.json
@@ -1750,6 +1750,7 @@
 	"report.domainGroup.save.button": "+ 将选定的主机名保存为一个组",
 	"report.edgeHostnameReq.label.requests": "请求数",
 	"report.edgeHostnameReq.label.requests.per.sec": "请求/秒",
+	"report.export.group.csv.text": "将组导出到 CSV",
 	"report.fast.req.label.requests": "快速通道请求数",
 	"report.fast.req.label.requests.per.sec": "每秒请求数",
 	"report.fast.vol.label.traffic.down.vol": "下载流量",


### PR DESCRIPTION
In the ngportal-language.babel file, testsuites previously added by junghoPark were also added.