### PR TITLE
NCP-4094 add the truncation note for attached editor context

### DIFF
--- a/ar_SA.json
+++ b/ar_SA.json
@@ -490,6 +490,7 @@
 	"chatbot.label.context.full.edge.logic": "Edge Logic",
 	"chatbot.label.context.remove": "إزالة",
 	"chatbot.label.context.tooltip.toggle": "تضمين Edge Logic بالكامل كسياق",
+	"chatbot.label.context.truncated": "(مقتطع)",
 	"chatbot.label.copied.message": "تم نسخها إلى الحافظة",
 	"chatbot.label.delete.button": "يمسح",
 	"chatbot.label.placeholder.loading.settings": "جارٍ تحميل الإعدادات...",

--- a/en_US.json
+++ b/en_US.json
@@ -490,6 +490,7 @@
 	"chatbot.label.context.full.edge.logic": "Edge Logic",
 	"chatbot.label.context.remove": "Remove",
 	"chatbot.label.context.tooltip.toggle": "Include the full Edge Logic as context",
+	"chatbot.label.context.truncated": "(truncated)",
 	"chatbot.label.copied.message": "Copied to clipboard",
 	"chatbot.label.delete.button": "Delete",
 	"chatbot.label.placeholder.loading.settings": "Loading settings...",

--- a/es_ES.json
+++ b/es_ES.json
@@ -490,6 +490,7 @@
 	"chatbot.label.context.full.edge.logic": "Edge Logic",
 	"chatbot.label.context.remove": "Quitar",
 	"chatbot.label.context.tooltip.toggle": "Incluir el Edge Logic completo como contexto",
+	"chatbot.label.context.truncated": "(truncado)",
 	"chatbot.label.copied.message": "Copiado al portapapeles",
 	"chatbot.label.delete.button": "BORRAR",
 	"chatbot.label.placeholder.loading.settings": "Cargando configuración...",

--- a/fr_FR.json
+++ b/fr_FR.json
@@ -490,6 +490,7 @@
 	"chatbot.label.context.full.edge.logic": "Edge Logic",
 	"chatbot.label.context.remove": "Retirer",
 	"chatbot.label.context.tooltip.toggle": "Inclure l'Edge Logic complet comme contexte",
+	"chatbot.label.context.truncated": "(tronqué)",
 	"chatbot.label.copied.message": "Copié dans le presse-papier",
 	"chatbot.label.delete.button": "SUPPRIMER",
 	"chatbot.label.placeholder.loading.settings": "Chargement des paramètres...",

--- a/it_IT.json
+++ b/it_IT.json
@@ -490,6 +490,7 @@
 	"chatbot.label.context.full.edge.logic": "Edge Logic",
 	"chatbot.label.context.remove": "Rimuovi",
 	"chatbot.label.context.tooltip.toggle": "Includi l'intero Edge Logic come contesto",
+	"chatbot.label.context.truncated": "(troncato)",
 	"chatbot.label.copied.message": "Copiato negli appunti",
 	"chatbot.label.delete.button": "Eliminare",
 	"chatbot.label.placeholder.loading.settings": "Caricamento delle impostazioni in corso...",

--- a/jk_KR.json
+++ b/jk_KR.json
@@ -490,6 +490,7 @@
 	"chatbot.label.context.full.edge.logic": "엣지 로직",
 	"chatbot.label.context.remove": "제거",
 	"chatbot.label.context.tooltip.toggle": "전체 엣지 로직을 컨텍스트로 포함",
+	"chatbot.label.context.truncated": "(잘림)",
 	"chatbot.label.copied.message": "클립보드에 복사됨",
 	"chatbot.label.delete.button": "삭제",
 	"chatbot.label.placeholder.loading.settings": "설정 불러오는 중...",

--- a/jp_JP.json
+++ b/jp_JP.json
@@ -490,6 +490,7 @@
 	"chatbot.label.context.full.edge.logic": "エッジロジック",
 	"chatbot.label.context.remove": "削除",
 	"chatbot.label.context.tooltip.toggle": "エッジロジック全体をコンテキストとして含める",
+	"chatbot.label.context.truncated": "(切り詰め)",
 	"chatbot.label.copied.message": "クリップボードにコピーされました",
 	"chatbot.label.delete.button": "消去",
 	"chatbot.label.placeholder.loading.settings": "設定を読み込んでいます...",

--- a/ru_RU.json
+++ b/ru_RU.json
@@ -492,6 +492,7 @@
 	"chatbot.label.context.full.edge.logic": "Edge Logic",
 	"chatbot.label.context.remove": "Удалить",
 	"chatbot.label.context.tooltip.toggle": "Включить полный Edge Logic в качестве контекста",
+	"chatbot.label.context.truncated": "(усечено)",
 	"chatbot.label.copied.message": "Скопировано в буфер обмена",
 	"chatbot.label.delete.button": "Удалить",
 	"chatbot.label.placeholder.loading.settings": "Загрузка настроек...",

--- a/zh-Hans.json
+++ b/zh-Hans.json
@@ -490,6 +490,7 @@
 	"chatbot.label.context.full.edge.logic": "边缘逻辑",
 	"chatbot.label.context.remove": "移除",
 	"chatbot.label.context.tooltip.toggle": "将完整的边缘逻辑作为上下文发送",
+	"chatbot.label.context.truncated": "（已截断）",
 	"chatbot.label.copied.message": "已复制到剪贴板",
 	"chatbot.label.delete.button": "删除",
 	"chatbot.label.placeholder.loading.settings": "正在加载设置...",


### PR DESCRIPTION
The chatbot now shows the Edge Logic attached to a sent question as hover pointers. When the attached copy was clamped before being sent to the model, the preview says so with chatbot.label.context.truncated.